### PR TITLE
Rename BATT_ALARM to BATT_ALERT

### DIFF
--- a/avr/variants/pinoccio/pins_arduino.h
+++ b/avr/variants/pinoccio/pins_arduino.h
@@ -45,7 +45,7 @@
 #define SDA             16
 
 #define VCC_ENABLE      17
-#define BATT_ALARM      18
+#define BATT_ALERT      18
 #define BACKPACK_BUS    19
 #define CHG_STATUS      20
 #define LED_BLUE        21


### PR DESCRIPTION
I realize this is a bit trivial but the schematic and other documentation including comments in this very file refer to that signal as BATT_ALERT. Feel free to reject this if I'm being too picky :-)
