### PR TITLE
Add analog pin to channel mapping macro

### DIFF
--- a/avr/variants/pinoccio/pins_arduino.h
+++ b/avr/variants/pinoccio/pins_arduino.h
@@ -71,6 +71,8 @@
 #define A6              30
 #define A7              31
 
+#define analogPinToChannel(p) ((p)>=A0?(p)-A0:(p))
+
 // ~: PWM, *: external interrupt
 // Pin num   Pin functions     Connected to / label on board
 // D0:  PE0  RXD0/PCINT8       RX0 (Connected to 16u2 USB chip)


### PR DESCRIPTION
This allows passing normal ("digital") pin numbers to analogRead as
well. E.g. to read from pin A0, you can now not only do analogRead(0),
but also analogRead(A0) or analogRead(24). Previously, doing so would
read from the wrong pins because the Arduino core contains a default
mapping, which is incorrect for the Pinoccio Scouts.
